### PR TITLE
[FEAT] 글쓰기 기능 추가

### DIFF
--- a/contents/urls.py
+++ b/contents/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from .views import CommentUploadView
+from .views      import CommentUploadView, PostUploadView
 
 urlpatterns = [
     path("/<int:post_id>/comment", CommentUploadView.as_view()),
+    path("/", PostUploadView.as_view()),
 ]

--- a/contents/views.py
+++ b/contents/views.py
@@ -7,7 +7,7 @@ from django.http     import JsonResponse
 from    core.views          import upload_fileobj
 from    my_settings         import MEDIA_URL, AWS_STORAGE_BUCKET_NAME
 from    core.utils          import login_decorator
-from    contents.models     import Comment
+from    contents.models     import Post, SubCategory, Comment
 
 bucket = AWS_STORAGE_BUCKET_NAME
 args   = {'ACL':'public-read'}
@@ -34,6 +34,47 @@ class CommentUploadView(View):
                 user_id = user.id,
                 image   = image_url,
                 post_id = post_id
+            )
+
+            return JsonResponse({'message' : "SUCCESS"}, status=201)
+
+        except KeyError :
+            return JsonResponse({"message" : "KEY_ERROR"}, status=400)
+            
+class PostUploadView(View):
+    @login_decorator
+    def post(self, request):
+        try:
+            content         = request.POST["content"]
+            reading_time    = datetime.time(0,int(len(content.replace(" ",""))/275+1),0)
+            user            = request.user
+            subcategory     = request.POST["subcategory"]
+            sub_title       = request.POST["sub_title"]
+            thumbnail_image = request.FILES.get('thumbnail_image', None)
+            color_code      = request.POST.get('color_code', None)
+            title           = request.POST["title"]
+
+            if thumbnail_image is not None:
+                if not str(thumbnail_image).split('.')[-1] in ['png', 'jpg', 'gif', 'jpeg']:
+                    return JsonResponse({"message" : "INVALID EXTENSION"}, status=400)
+
+                key = "/thumbnail_image/" + str(user.id) + "/" + str(thumbnail_image) 
+
+                upload_fileobj(Fileobj=thumbnail_image, Bucket=bucket, Key=key, ExtraArgs=args)
+                thumbnail_image = MEDIA_URL + key
+
+            else:
+                thumbnail_image = color_code
+
+            Post.objects.create(
+                content         = content,
+                user_id         = user.id,
+                subcategory_id  = SubCategory.objects.get(id=1).id,
+                sub_title       = sub_title,
+                thumbnail_image = thumbnail_image,
+                title           = title,
+                reading_time    = reading_time,
+>>>>>>> bcf0e69 ([FEAT] 글쓰기 기능 추가)
             )
 
             return JsonResponse({'message' : "SUCCESS"}, status=201)

--- a/core/utils.py
+++ b/core/utils.py
@@ -4,7 +4,6 @@ import json
 from django.http    import JsonResponse
 from django.conf    import settings
 
-
 from users.models   import User
 
 def login_decorator(func):
@@ -20,5 +19,6 @@ def login_decorator(func):
 
         except User.DoesNotExist:
             return JsonResponse({"message" : "INVAILD_USER"}, status = 400)
+
         return func(self, request, *args, **kwargs)
     return wrapper


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
 글쓰기 기능 추가
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. core앱
-글쓰기 내 이미지 업로드 기능 커밋에서 관련 내용을 추가했기 때문에 생략

2. content앱
-postupload view에는 png, jpg, gif, jpeg 확장자 말고는 들어 올 수 없게 예외
처리 -> 이미지 업로드 공간이고 제목에 이미지 파일만 가능하기 때문에 예외처리
    
- key는 "thumbnail_image" + user.id + thumbnail_image로 구성-> 해당 key와 media_url(aws 버킷 네임과 리전 주소를 포함한 media_ulr)로 만든 object_name을 그대
로 db에 저장
    
-reading_time에 경우 다른 사이트들을 참고하여 1분에 275자씩 읽는 다고 가정하고 계산
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)


<br />

## :: 기타 질문 및 특이 사항
test.py 내 s3 관련해서 조언을 주신다고 해서 일단 한데까지 올렸습니다!