### PR TITLE
 [FEAT] 이메일 제안서 발송 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,4 +253,6 @@ zsdoc/data
 
 # End of https://www.toptal.com/developers/gitignore/api/python,zsh,macos,visualstudiocode
 
+credentials.json
+token.json
 my_settings.py

--- a/authors/app.py
+++ b/authors/app.py
@@ -1,0 +1,62 @@
+import os.path
+import base64
+
+from django.http     import JsonResponse
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials      import Credentials
+from google_auth_oauthlib.flow      import InstalledAppFlow
+from googleapiclient.discovery      import build
+from  email.message                 import EmailMessage
+import google.auth
+
+SCOPES =['https://www.googleapis.com/auth/gmail.send']
+
+class GoogleEmail:
+    def __init__(self, credentials):
+        self.credentials = credentials
+
+    def generate_token(self, file_path):
+        creds = None
+
+        if os.path.exists('token.json'):
+            creds = Credentials.from_authorized_user_file('token.json', SCOPES)
+
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    'credentials.json', SCOPES)
+                creds = flow.run_local_server(port=0)
+    
+            with open('token.json', 'w') as token:
+                token.write(creds.to_json())
+
+        return creds
+
+    def send_email(self, content, author, sender_email, creds):
+        
+        service = build('gmail', 'v1', credentials=creds)
+
+        content = "제안자 : " + sender_email + "/n" + "제안 내용 : " + content
+
+        message = EmailMessage()
+
+        message.set_content(content)
+
+        message['To']      = author.user.email
+        message['From']    = "ebsgreat7@gmail.com"
+        message['Subject'] = "작가" + author.user.name + '에게 제안메일 드립니다'
+
+        encoded_message = base64.urlsafe_b64encode(message.as_bytes()).decode()
+
+        create_message  = {
+            'raw': encoded_message
+        }
+
+        send_message = service.users().messages().send(userId='me', body=create_message).execute()
+        
+        return JsonResponse({"message" : "SUCCESS"}, status=200)
+
+

--- a/authors/tests.py
+++ b/authors/tests.py
@@ -1,3 +1,86 @@
-from django.test import TestCase
+import json
+import bcrypt
+import jwt
 
-# Create your tests here.
+from django.test import TestCase, Client
+from json        import dumps
+from django.conf import settings
+
+from .models  import Author, User, ProposalObject, Proposal
+from unittest import mock
+from unittest.mock import patch, MagicMock
+
+class EmailTest(TestCase):
+    def setUp(self):
+        User.objects.create(
+            id           = 1,
+            email        = "dno06103@naver.com",
+            name         = "김민정",
+            thumbnail    = "저거.png",
+            introduction = "블라블라블라블라",
+        )
+
+        Author.objects.create(
+            id           = 1,
+            introduction = "블라블라",
+            career       = "블라블라블라블라",
+            user_id      = 1
+        )
+
+        ProposalObject.objects.create(
+            id = 1,
+            name = "출판기고",
+        )
+        
+        self.token = jwt.encode({'id':User.objects.get(id=1).id}, settings.SECRET_KEY, settings.ALGORITHM)
+
+    def tearDown(self):
+        Author.objects.all().delete()
+        User.objects.all().delete()
+        Proposal.objects.all().delete()
+
+    @patch("authors.app.GoogleEmail")
+    def test_success_proposalview_post(self, mocked_requests):
+        client = Client()
+        data = {
+            "content"        : "블라블라",
+            "sender_email"   : "dno06101@naver.com",
+            "proposal_object": "출판기고"
+        }
+    
+        headers = {"HTTP_Authorization": self.token}
+
+        class MockedResponse:
+            # def __init__(self):
+            #     credentials = credentials
+
+            def generate_token(self, file_path):
+                return "<google.oauth2.credentials.Credentials object at 0x111a4ff10>"
+
+            file_path = 'token.json'
+
+            def send_email(self, content, author, sender_email, creds):
+                return JsonResponse({"message" : "SUCCESS"}, status=200)            
+
+            content      = "블라블라"
+            sender_email = "dno06103@naver.com"
+            author       = Author.objects.get(id=1)
+            creds        = generate_token(self, file_path)
+
+        access_token = headers["HTTP_Authorization"]
+        payload      = jwt.decode(access_token, settings.SECRET_KEY, algorithms = settings.ALGORITHM)
+        user         = User.objects.get(id = payload["id"])
+
+        Proposal.objects.create(
+            sender_email       = "dno06103@naver.com",
+            content            = "블라블라",
+            proposal_object_id = 1,
+            author_id          = 1,
+            user_id            = user.id
+        )
+        mocked_requests.return_value = MockedResponse()
+
+        response = client.post('/authors/1', json.dumps(data), content_type='application/json', **headers)
+
+        self.assertEqual(response.json(), {'message' : 'SUCCESS'})
+        self.assertEqual(response.status_code, 201)

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -1,4 +1,7 @@
 from django.urls import path
 
+from authors.views import ProposalView
+
 urlpatterns = [
+    path("/<int:author_id>", ProposalView.as_view()),
 ]

--- a/authors/views.py
+++ b/authors/views.py
@@ -1,3 +1,35 @@
-from django.shortcuts import render
+import json
 
-# Create your views here.
+from django.views    import View
+from django.http     import JsonResponse
+
+from googleapiclient.errors         import HttpError
+from core.utils                     import login_decorator
+from authors.models                 import Author, Proposal, ProposalObject
+from google.oauth2.credentials      import Credentials
+from authors.app                    import GoogleEmail
+
+class ProposalView(View):
+    @login_decorator
+    def post(self, request, author_id):
+        try:
+            data            = json.loads(request.body)
+            content         = data["content"]
+            sender_email    = data["sender_email"]
+            proposal_object = data["proposal_object"]
+            author          = Author.objects.get(id=author_id)
+            google_email = GoogleEmail(credentials="credentials.json")
+            creds        = google_email.generate_token(file_path="token.json")
+            google_email.send_email(content = content, author = author, sender_email = sender_email, creds=creds)
+           
+            Proposal.objects.create(
+                sender_email       = sender_email,
+                content            = content,
+                proposal_object_id = ProposalObject.objects.get(name=proposal_object).id,
+                author_id          = author.id,
+                user_id            = request.user.id
+            )
+        except HttpError as error:
+            send_message = None
+
+        return JsonResponse({"message" : "SUCCESS"}, status=201)

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,12 +1,8 @@
 import jwt
 import json
-
 from django.http    import JsonResponse
 from django.conf    import settings
-
-
 from users.models   import User
-
 def login_decorator(func):
     def wrapper(self, request, *args, **kwargs):
         try:
@@ -14,13 +10,9 @@ def login_decorator(func):
             payload      = jwt.decode(access_token, settings.SECRET_KEY, algorithms = settings.ALGORITHM)
             user         = User.objects.get(id = payload["id"])
             request.user = user
-
-
         except jwt.exceptions.DecodeError:
             return JsonResponse({"message" : "INVALID TOKEN"}, status = 400)
-
         except User.DoesNotExist:
             return JsonResponse({"message" : "INVAILD_USER"}, status = 400)
-            
         return func(self, request, *args, **kwargs)
     return wrapper

--- a/users/views.py
+++ b/users/views.py
@@ -1,13 +1,13 @@
 import jwt
 import requests
 
-from django.http import JsonResponse
-from django.views import View
-from django.shortcuts import redirect
-from django.conf import settings
-from django.db import transaction
+from django.http        import JsonResponse
+from django.views       import View
+from django.shortcuts   import redirect
+from django.conf        import settings
+from django.db          import transaction
 
-from users.models import SocialAccount, User
+from users.models       import SocialAccount, User
 
 class KakaoLoginView(View):
     def get(self, request):


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
이메일 제안서 발송 기능
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
-credentials.json -> 구글 클라우드 플랫폼에서 관련 토큰을 받기 위한 정보를 담은 파일 다운로드
-token.json -> credentials.json을 통해 발급
-app.py -> 제안서는 ebsgreat7@gmail.com-> branchtime 관리자가 보내지만 제안하는 사람의 이메일을 제안서에 첨부해야 하기 때문에 content에 첨부해서 이메일 보내는 로직 구성
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)


<br />

## :: 기타 질문 및 특이 사항
1.메일은 보내지지만 AttributeError: 'dict' object has no attribute 'has_header' 라고 나오고 500에러가 나오는데 어떻게 해결해야할지 조언이 필요합니다.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/96784345/173231771-6bf2c64d-c649-4107-aa4b-f4228a0c6392.png">

2. credentials.json과 token.json도 숨겨야 할 것 같아서 .gitignore에 넣어봤는데 (생각해보니깐 gitignore에 넣어야 할 부분은 아닌것 같기는 합니다..) 숨겨지지 않습니다. 이 정보는 이렇게 들어내놓아도 되나요?